### PR TITLE
Modify predict behavior 

### DIFF
--- a/EIMedSeg3D/Resources/UI/EIMedSeg3D.ui
+++ b/EIMedSeg3D/Resources/UI/EIMedSeg3D.ui
@@ -189,9 +189,9 @@
     </layout>
    </item>
    <item>
-    <widget class="QPushButton" name="clearPointButton">
+    <widget class="QPushButton" name="finishSegmentButton">
      <property name="text">
-      <string>Clear Points</string>
+      <string>Finish Segment</string>
      </property>
     </widget>
    </item>

--- a/EIMedSeg3D/inference/predictor.py
+++ b/EIMedSeg3D/inference/predictor.py
@@ -15,10 +15,10 @@ from inference.ops import DistMaps3D, ScaleLayer, BatchImageNormalize3D, Sigmoid
 
 class Click:
     def __init__(self, is_positive, coords, indx=None):
-        if coord is None or is_positive is None:
+        if coords is None or is_positive is None:
             raise ValueError("The coord is {}, is_positive is {} and one of them is None, but none of them should be.")
-        self.coord = coord
-        self.is_positive = isPositivePoint
+        self.coords = coords
+        self.is_positive = is_positive
         self.index = None
 
     @property


### PR DESCRIPTION
在一个segment下点击推理，检查当前segment是否为空
- 为空：结果直接放到这个segment
- 不为空：创建一个同名空segment存结果

流程
- 刚进入一个task为不在交互式分割状态
- 点击placepoint button或添加一个点，进入交互式分割状态
  - 进行上面说的segment是否为空操作
  - 禁用segmenteditor(这样可以确保交互式过程currentSegment里只有交互式结果，没有导入的或者用户画的，也不会切换segment)
  - 重新初始化交互式（input_data单拿出去放在切task里了）
- Finish Segment：保存结果

ps: 没有做不保存结果退出，这个功能可以很简单的通过保存退出之后删除segment实现